### PR TITLE
include textures and samplers in Gltf struct + fix sample viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ nanoserde = "0.1"
 [dev-dependencies]
 miniquad = { version = "0.4.0-alpha", features = ["log-impl"] }
 shadermagic = "0.1"
-glam = "0.24"
+glam = "0.25"
 dolly = "0.4"
 zune-png = "0.2"
 zune-jpeg = "0.3"

--- a/examples/viewer/cubemap.rs
+++ b/examples/viewer/cubemap.rs
@@ -95,7 +95,7 @@ impl Cubemap {
 
         let display_bind = Bindings {
             vertex_buffers: vec![vertex_buffer],
-            index_buffer: index_buffer,
+            index_buffer,
             images: vec![color_img],
         };
 
@@ -110,7 +110,7 @@ impl Cubemap {
         };
         let default_shader = ctx.new_shader(source, display_shader::meta()).unwrap();
 
-        let display_pipeline = ctx.new_pipeline_with_params(
+        let display_pipeline = ctx.new_pipeline(
             &[BufferLayout::default()],
             &[
                 VertexAttribute::new("in_pos", VertexFormat::Float3),

--- a/examples/viewer/image.rs
+++ b/examples/viewer/image.rs
@@ -12,7 +12,7 @@ pub fn decode(bytes: &[u8]) -> Option<RGBA8Buffer> {
         use zune_jpeg::JpegDecoder;
 
         let options = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
-        let mut decoder = JpegDecoder::new_with_options(bytes, options);
+        let mut decoder = JpegDecoder::new_with_options(options, bytes);
         decoder.decode_headers().ok()?;
         let info = decoder.info()?;
         let pixels = decoder.decode().ok()?;

--- a/examples/viewer/loader.rs
+++ b/examples/viewer/loader.rs
@@ -208,7 +208,7 @@ pub fn load_gltf(ctx: &mut miniquad::Context, json: &str) -> Model {
                 .new_shader(source, shader::meta())
                 .unwrap_or_else(|e| panic!("Failed to load shader: {}", e));
 
-            let pipeline = ctx.new_pipeline_with_params(
+            let pipeline = ctx.new_pipeline(
                 &[
                     BufferLayout::default(),
                     BufferLayout::default(),

--- a/examples/viewer/main.rs
+++ b/examples/viewer/main.rs
@@ -169,5 +169,7 @@ fn main() {
         conf.platform.linux_x11_gl = conf::LinuxX11Gl::EGLOnly;
     }
 
+    conf.sample_count = 4;
+
     miniquad::start(conf, move || Box::new(Stage::new()));
 }

--- a/src/gltf.rs
+++ b/src/gltf.rs
@@ -25,6 +25,10 @@ pub struct Gltf {
     #[nserde(default)]
     pub buffer_views: Vec<BufferView>,
     #[nserde(default)]
+    pub textures: Vec<Texture>,
+    #[nserde(default)]
+    pub samplers: Vec<Sampler>,
+    #[nserde(default)]
     pub images: Vec<Image>,
     #[nserde(default)]
     pub scenes: Vec<Scene>,


### PR DESCRIPTION
Sampler and Texture where forgotten from the Gltf struct, so added them

also fixed compilation errors in sample due to differing glam versions in dolly and example as well as small miniquad change to API